### PR TITLE
Bug fixes w/ current Github API

### DIFF
--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Bookmark2md",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "default_locale": "zh_CN",
   "description": "__MSG_description__",
   "icons": {

--- a/Extension/scripts/options.js
+++ b/Extension/scripts/options.js
@@ -5,7 +5,7 @@
 let Bookmark2Github = new OAuth2('github', {
   client_id: '004b7c9e59a81dfae785',
   client_secret: 'afc402eef1fb5a2788dffee8477d0964511a524b',
-  api_scope: 'repo%20user'
+  api_scope: 'repo'
 })
 
 let pushCount = {

--- a/Extension/scripts/options.js
+++ b/Extension/scripts/options.js
@@ -5,7 +5,7 @@
 let Bookmark2Github = new OAuth2('github', {
   client_id: '004b7c9e59a81dfae785',
   client_secret: 'afc402eef1fb5a2788dffee8477d0964511a524b',
-  api_scope: 'repo'
+  api_scope: 'repo%20user'
 })
 
 let pushCount = {
@@ -64,19 +64,19 @@ function getUserInfo () {
 }
 
 function getUserRepos (userInfo, page = 1) {
-  let url = `${ userInfo.repos_url }?per_page=100&page=${ page }`
+  let url = `https://api.github.com/search/repositories?q=user:${ userInfo.login }&per_page=100&page=${ page }`
   showLoading('Loading user repos...')
   $.ajax({
     type: 'GET',
     url: url,
     headers: {
-      Authorization: `token ${Bookmark2Github.access_token}`
+      Authorization: `token ${Bookmark2Github.access_token}`,
     },
     success: function (res) {
       hideLoading()
       Bookmark2Github.userRepos = res
       let repoList = []
-      res.map(item => {
+      res.items.map(item => {
         allRepoList.push(item.name)
         repoList.push(`<option value="${ item.name }">${ item.name }</option>`)
       })
@@ -164,10 +164,6 @@ function putContent (fileName, fileContent) {
     let url = `https://api.github.com/repos/${ owner }/${ repo }/contents/${ path }`
     let data = {
       message: msg,
-      committer: {
-        name: Bookmark2Github.userInfo.name,
-        email: Bookmark2Github.userInfo.email
-      },
       branch: branch,
       content: Base64.encode(fileContent)
     }
@@ -208,6 +204,7 @@ function doPush () {
     }
     bookmark2md.transfer(exclusion, maxLevel, function (fileMap) {
       let fileNameArr = Object.keys(fileMap)
+      console.log(fileMap)
       let i = 0
       pushCount.total = fileNameArr.length
       let handler = function () {


### PR DESCRIPTION
I tried using the extension and kept getting failure responses, so I changed a couple of things for it to work with the current Github API.

Changed repository list fetching URL since it retrieves only public repos. Changed from `/orgs/${user}/repos` to `search/repositories?q=user:${user}` according to [this thread](https://github.community/t/how-to-get-list-of-private-repositories-via-api-call/120175/4) and [Github's API documentation](https://docs.github.com/en/rest/search#search-repositories).

Removed `committer` from `putContent()` since according to the [repository API documentation](https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents) it defaults to correct values.
I got to this since my own email is hidden, which caused the extension to fail.

I also bumped the version.

Hope you approve this and re-publish the extension, it looks like a good productivity tool.

Cheers,
Uri